### PR TITLE
Add ability to use all NoiseMakerProps

### DIFF
--- a/LethalCompanyTemplate/Patches.cs
+++ b/LethalCompanyTemplate/Patches.cs
@@ -16,6 +16,7 @@ namespace Poltergeist
     {
         //Config things
         public static bool defaultMode = false;
+        public static bool allowAllNoiseMakerProps = false;
 
         //Other fields
         public static bool vanillaMode = false;
@@ -116,7 +117,7 @@ namespace Poltergeist
         }
 
         /**
-         * Add ghost interactor objects to airhorns and clownhorns
+         * Add ghost interactor objects to airhorns and clownhorns and any other prop, if `allowAllNoiseMakerProps` is set to `true`
          * 
          * @param __instance The calling noise prop
          */
@@ -124,7 +125,7 @@ namespace Poltergeist
         [HarmonyPatch(typeof(NoisemakerProp), "Start")]
         public static void AddInteractorForHorns(NoisemakerProp __instance)
         {
-            if (__instance.name.Contains("Airhorn") || __instance.name.Contains("Clownhorn"))
+            if (__instance.name.Contains("Airhorn") || __instance.name.Contains("Clownhorn") || allowAllNoiseMakerProps)
             {
                 __instance.gameObject.AddComponent<GhostInteractible>();
             }

--- a/LethalCompanyTemplate/Poltergeist.cs
+++ b/LethalCompanyTemplate/Poltergeist.cs
@@ -18,6 +18,10 @@ namespace Poltergeist
                 "DefaultToVanilla",
                 false,
                 "If true, the vanilla spectate system will be used by default on death.").Value;
+            Patches.allowAllNoiseMakerProps = Config.Bind<bool>("General",
+                "AllowAllNoiseMakerProps",
+                false,
+                "If true, allows the use of any noise maker prop. (For example cash registers)").Value;
             SpectatorCamController.lightIntensity = Config.Bind<float>("General",
                 "GhostLightIntensity",
                 5,


### PR DESCRIPTION
I think it should be possible to use any NoiseMakerProps.

This should add support for modded items and items like the cash register ^^

I made it configurable and turned it off by default to honor your decision to only make it work for horns.

I hope this will be merged :)